### PR TITLE
Less ambigious description for "krom.kromPath"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 				"krom.kromPath": {
 					"type": "string",
 					"default": "",
-					"description": "Points to a Krom directory."
+					"description": "Points to a directory containing the Krom executable."
 				}
 			}
 		}


### PR DESCRIPTION
"Krom directory" could also mean the Krom directory, but that just silently does nothing (in an ideal world, there would also be a nice error message for that).