### PR TITLE
Remove "configuration" from the settings title

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"contributes": {
 		"configuration": {
 			"type": "object",
-			"title": "Krom configuration",
+			"title": "Krom",
 			"properties": {
 				"krom.kromPath": {
 					"type": "string",


### PR DESCRIPTION
It looks redundant in VSCode's new Settings UI / most extensions just use the extension name.

![](https://i.imgur.com/9v3Iqne.png)